### PR TITLE
Allow empty values to support wagtail drafts

### DIFF
--- a/django_choices_field/fields.py
+++ b/django_choices_field/fields.py
@@ -12,7 +12,6 @@ from typing import (
     cast,
 )
 
-from django.core import validators
 from django.core.exceptions import ValidationError
 from django.db import models
 
@@ -44,7 +43,6 @@ class TextChoicesField(models.CharField):
     default_error_messages: ClassVar[Dict[str, str]] = {
         "invalid": "“%(value)s” must be a subclass of %(enum)s.",
     }
-    empty_values = list(validators.EMPTY_VALUES)
 
     def __init__(
         self,

--- a/django_choices_field/fields.py
+++ b/django_choices_field/fields.py
@@ -12,6 +12,7 @@ from typing import (
     cast,
 )
 
+from django.core import validators
 from django.core.exceptions import ValidationError
 from django.db import models
 
@@ -43,6 +44,7 @@ class TextChoicesField(models.CharField):
     default_error_messages: ClassVar[Dict[str, str]] = {
         "invalid": "“%(value)s” must be a subclass of %(enum)s.",
     }
+    empty_values = list(validators.EMPTY_VALUES)
 
     def __init__(
         self,
@@ -62,7 +64,7 @@ class TextChoicesField(models.CharField):
         super().__init__(verbose_name=verbose_name, name=name, **kwargs)
 
     def to_python(self, value):
-        if value is None:
+        if value in self.empty_values:
             return None
 
         try:

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -177,6 +177,13 @@ def test_set_text_integer(db):
     assert m.i_field == 2
 
 
+def test_set_empty_value_text(db):
+    # Passing an empty value should not raise an error
+    m = MyModel()
+    m.c_field_nullable = ""
+    m.save()
+
+
 @pytest.mark.parametrize("v", [10, "abc"])
 def test_set_wrong_value_text(v, db):
     m = MyModel()


### PR DESCRIPTION
While using Wagtail, if any field is a `TextChoicesField`, leaving it blank causes a 500 error due to the ValidationError raised.

This allows handling of empty values more loosely, just like Django's TextField has:

https://github.com/django/django/blob/a3b1107a4955bdd994908efb4c6e1d03c281e69f/django/db/models/fields/__init__.py#L807

I verified that switching to this, or switching to a plain `CharField(choices=...)` instead of a `TextChoicesField`, both fix the issue.

But without this change, this library breaks the wagtail admin entirely. The draft is not editable once it gets into this state.