### PR TITLE
Properly convert choices values to avoid "ENUM_VALUE" must be a subclass of ChoicesEnum

### DIFF
--- a/django_choices_field/fields.py
+++ b/django_choices_field/fields.py
@@ -55,7 +55,9 @@ class TextChoicesField(models.CharField):
             self.choices_enum = choices_enum
             kwargs["choices"] = choices_enum.choices
         elif "choices" in kwargs:
-            self.choices_enum = models.TextChoices("ChoicesEnum", kwargs["choices"])
+            self.choices_enum = models.TextChoices(
+                "ChoicesEnum", [(k, (k, v)) for k, v in kwargs["choices"]]
+            )
         else:
             raise TypeError("either of choices_enum or choices must be provided")
         kwargs.setdefault("max_length", max(len(c[0]) for c in kwargs["choices"]))


### PR DESCRIPTION
The change from #26 broke all past migrations on a project where I'm using this library.

The error would be something like this:

```
django.core.exceptions.ValidationError: ["“FULL_COURSE” must be a subclass of <enum 'ChoicesEnum'>."]
```

And after some digging, what was happening is that the converted choices are incorrect. Dropping into `TextChoicesField.__init__` I was seeing this:

For this enum:
```python
class CourseType(models.TextChoices):
    FULL_COURSE = "FULL_COURSE", "Full course"
    MICRO_COURSE = "MICRO_COURSE", "Micro course"
```

```
(Pdb) p kwargs["choices"]
[('FULL_COURSE', 'Full course'), ('MICRO_COURSE', 'Micro course')]  # correct
(Pdb) p models.TextChoices("ChoicesEnum", kwargs["choices"]).choices
[('Full course', 'Full Course'), ('Micro course', 'Micro Course')]  # incorrect
```

Django does this conversion right here: https://github.com/django/django/blob/fda3c1712a1eb7b20dfc91e6c9abae32bd64d081/django/db/models/enums.py#L25

We must pass a tuple so that the values don't get converted.
