### PR TITLE
support labels for blank values

### DIFF
--- a/django_choices_field/fields.py
+++ b/django_choices_field/fields.py
@@ -53,7 +53,7 @@ class TextChoicesField(models.CharField):
     ):
         if choices_enum is not None:
             self.choices_enum = choices_enum
-            kwargs["choices"] = choices_enum.choices
+            kwargs["choices"] = [(x.value, x.label) for x in choices_enum]
         elif "choices" in kwargs:
             self.choices_enum = models.TextChoices(
                 "ChoicesEnum",
@@ -100,7 +100,7 @@ class IntegerChoicesField(models.IntegerField):
     ):
         if choices_enum is not None:
             self.choices_enum = choices_enum
-            kwargs["choices"] = choices_enum.choices
+            kwargs["choices"] = [(x.value, x.label) for x in choices_enum]
         elif "choices" in kwargs:
             enum_members = _get_integer_enum_members(kwargs["choices"])
             self.choices_enum = models.IntegerChoices("ChoicesEnum", enum_members)
@@ -153,7 +153,7 @@ class IntegerChoicesFlagField(models.IntegerField):
         if choices_enum is not None:
             self.choices_enum = choices_enum
 
-            default_choices = choices_enum.choices
+            default_choices = [(x.value, x.label) for x in choices_enum]
             kwargs["choices"] = default_choices[:]
             for i in range(1, len(default_choices)):
                 for combination in itertools.combinations(default_choices, i + 1):

--- a/tests/models.py
+++ b/tests/models.py
@@ -33,6 +33,8 @@ class MyModel(models.Model):
         )
 
     class IntegerFlagEnumTranslated(IntegerChoicesFlag):
+        __empty__ = _("this is the label for the empty value")
+
         IF_FOO = (
             enum.auto() if sys.version_info >= (3, 11) else 1,
             _("IF Foo Description"),  # type: ignore


### PR DESCRIPTION
This adds support for blank labels on nullable choices fields by using the `__empty__` value to set the label. This feature is deeply hidden in the Django documentation in the bottom of the section around ["Enumeration Types"](https://docs.djangoproject.com/en/5.2/ref/models/fields/#enumeration-types):

> Because an enumeration with a concrete data type requires all values
> to match the type, overriding the blank label cannot be achieved by
> creating a member with a value of None. Instead, set the `__empty__`
> attribute on the class:
>
> ```
>     class Answer(models.IntegerChoices):
>         NO = 0, _("No")
>         YES = 1, _("Yes")
>
>         __empty__ = _("(Unknown)")
> ```

The empty value is included in `<enum_type>.choices` as `(None, "label")` but can be avoided with `[(x.value, x.label) for x in <enum_type>]`.